### PR TITLE
Refactor content-type and error handling in receptor client

### DIFF
--- a/client.go
+++ b/client.go
@@ -258,15 +258,13 @@ func (c *client) do(req *http.Request, responseObject interface{}) error {
 func handleJSONResponse(res *http.Response, responseObject interface{}) error {
 	if res.StatusCode > 299 {
 		errResponse := Error{}
-		err := json.NewDecoder(res.Body).Decode(&errResponse)
-		if err != nil {
+		if err := json.NewDecoder(res.Body).Decode(&errResponse); err != nil {
 			return Error{Type: InvalidJSON, Message: err.Error()}
 		}
 		return errResponse
 	}
 
-	err := json.NewDecoder(res.Body).Decode(responseObject)
-	if err != nil {
+	if err := json.NewDecoder(res.Body).Decode(responseObject); err != nil {
 		return Error{Type: InvalidJSON, Message: err.Error()}
 	}
 	return nil
@@ -279,6 +277,5 @@ func handleNonJSONResponse(res *http.Response) error {
 			Message: fmt.Sprintf("Invalid Response with status code: %d", res.StatusCode),
 		}
 	}
-
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -69,17 +69,24 @@ var _ = Describe("Receptor Client", func() {
 		}
 
 		BeforeEach(func() {
-			httpHeaders = http.Header{receptor.ContentTypeHeader: []string{receptor.JSONContentType}}
+			httpHeaders = http.Header{}
 			fakeReceptorServer.AppendHandlers(
 				ghttp.RespondWithPtr(&statusCode, &responseBody, httpHeaders),
 			)
 		})
 
 		Context("when the client receives json content", func() {
+			BeforeEach(func() {
+				httpHeaders[receptor.ContentTypeHeader] = []string{receptor.JSONContentType}
+			})
+
 			Context("when the http status code is not successful", func() {
 				It("returns a json-encoded error from the server", func() {
 					statusCode = http.StatusNotFound
-					lrpError := receptor.Error{Type: receptor.DesiredLRPNotFound, Message: "Desired LRP with guid 'unicorns' not found"}
+					lrpError := receptor.Error{
+						Type:    receptor.DesiredLRPNotFound,
+						Message: "Desired LRP with guid 'unicorns' not found",
+					}
 					responseBytes, err := json.Marshal(lrpError)
 					Expect(err).ToNot(HaveOccurred())
 					responseBody = string(responseBytes)
@@ -91,8 +98,8 @@ var _ = Describe("Receptor Client", func() {
 				})
 
 				It("returns an invalid json error for invalid json", func() {
-					responseBody = `{"key": "value}`
 					statusCode = http.StatusNotFound
+					responseBody = `{"key": "value}`
 
 					_, err := client.GetDesiredLRP("unicorns")
 
@@ -103,8 +110,8 @@ var _ = Describe("Receptor Client", func() {
 
 			Context("when the http status code is successful", func() {
 				It("returns an invalid json error for invalid json", func() {
-					responseBody = `{"key": "value}`
 					statusCode = http.StatusOK
+					responseBody = `{"key": "value}`
 
 					_, err := client.GetDesiredLRP("unicorns")
 
@@ -115,22 +122,26 @@ var _ = Describe("Receptor Client", func() {
 		})
 
 		Context("when the client receives non-json content", func() {
+			BeforeEach(func() {
+				httpHeaders[receptor.ContentTypeHeader] = []string{"text/plain; charset=utf-8"}
+			})
+
 			Context("when the http status code is 404", func() {
-				It("returns a resource not found error", func() {
+				It("returns an invalid response error", func() {
 					statusCode = http.StatusNotFound
 					responseBody = "404 page not found"
 
 					_, err := client.DesiredLRPs()
+
 					Expect(err).To(HaveOccurred())
-					Expect(err.(receptor.Error).Type).To(Equal(receptor.InvalidJSON))
+					Expect(err.(receptor.Error).Type).To(Equal(receptor.InvalidResponse))
 				})
 
 				Context("when there is an x-cf-routererror", func() {
 					It("returns a router error", func() {
 						statusCode = http.StatusNotFound
-						expectedErrorMessage := "unknown_route"
-						httpHeaders[receptor.ContentTypeHeader] = []string{"text/plain; charset=utf-8"}
 						httpHeaders[receptor.XCfRouterErrorHeader] = []string{"unknown_route"}
+						expectedErrorMessage := "unknown_route"
 
 						_, err := client.DesiredLRPs()
 
@@ -142,8 +153,8 @@ var _ = Describe("Receptor Client", func() {
 			Context("when the http status code is not successful and not 404", func() {
 				It("returns an invalid response error", func() {
 					statusCode = http.StatusGone
-					expectedErrorMessage := "Invalid Response with status code: 410"
 					httpHeaders[receptor.ContentTypeHeader] = []string{"image/gif"}
+					expectedErrorMessage := "Invalid Response with status code: 410"
 
 					_, err := client.DesiredLRPs()
 
@@ -152,12 +163,12 @@ var _ = Describe("Receptor Client", func() {
 			})
 		})
 
-		Describe("handling invalid/messy content types", func() {
+		Context("when the client receives empty/messy content types", func() {
 			Context("when the response is missing the content-type header", func() {
-				It("does not return error for success http status codes", func() {
+				It("does not return error for successful http status codes", func() {
 					statusCode = http.StatusNoContent
-					responseBody = ""
 					httpHeaders[receptor.ContentTypeHeader] = []string{}
+					responseBody = ""
 
 					_, err := client.DesiredLRPs()
 
@@ -168,6 +179,7 @@ var _ = Describe("Receptor Client", func() {
 			Context("when the content-type is formatted funny", func() {
 				It("figures it out and works", func() {
 					statusCode = http.StatusOK
+					httpHeaders[receptor.ContentTypeHeader] = []string{" aPPLiCaTioN/JSoN  ; charset=ISO-8859-8"}
 					lrpResponse := receptor.DesiredLRPResponse{
 						ProcessGuid: "some-guid",
 						Domain:      "diego",
@@ -175,7 +187,6 @@ var _ = Describe("Receptor Client", func() {
 					responseBytes, err := json.Marshal(lrpResponse)
 					Expect(err).ToNot(HaveOccurred())
 					responseBody = string(responseBytes)
-					httpHeaders[receptor.ContentTypeHeader] = []string{" aPPLiCaTioN/JSoN  ; charset=ISO-8859-8"}
 
 					response, err := client.GetDesiredLRP("some-guid")
 

--- a/errors.go
+++ b/errors.go
@@ -30,7 +30,6 @@ const (
 
 	ActualLRPIndexNotFound = "ActualLRPIndexNotFound"
 
-	ResourceNotFound = "ResourceNotFound"
 	ResourceConflict = "ResourceConflict"
 	RouterError      = "RouterError"
 )


### PR DESCRIPTION
Diego team,

These are some clean-up changes to the content-type / error handling added to receptor for [**#92451514**](https://www.pivotaltracker.com/story/show/92451514).  It's mostly identical logic, aside from a correcting the setup + assertions on a [test](https://github.com/davidwadden/receptor/commit/7cefb5c11b04227b2cf52e243dd5971cacb300d2#diff-51565ad50d7426213c2f33579f6f0e71L125) that should not return **InvalidJSON**, since the **Content-Type** is *text/plain*.  (but the test setup was wrong so the client was actually receiving JSON, so the implementation logic is correct)

I've also removed the ResourceNotFound error since it's no longer referenced and grouped some test logic into setup blocks.

Thanks!
David
